### PR TITLE
Files with encoding different from "Default" cannot be parsed

### DIFF
--- a/src/Pickles/Pickles.CommandLine/NLog.xsd
+++ b/src/Pickles/Pickles.CommandLine/NLog.xsd
@@ -42,12 +42,32 @@
     </xs:attribute>
     <xs:attribute name="throwExceptions" type="xs:boolean">
       <xs:annotation>
-        <xs:documentation>Pass NLog internal exceptions to the application. Default value is: false.</xs:documentation>
+        <xs:documentation>Throw an exception when there is an internal error. Default value is: false.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="throwConfigExceptions" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Throw an exception when there is a configuration error. If not set, determined by throwExceptions.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="keepVariablesOnReload" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Gets or sets a value indicating whether Variables should be kept on configuration reload. Default value is: false.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="internalLogToTrace" type="xs:boolean">
       <xs:annotation>
-        <xs:documentation>Write internal NLog messages to the the System.Diagnostics.Trace. Default value is: false</xs:documentation>
+        <xs:documentation>Write internal NLog messages to the System.Diagnostics.Trace. Default value is: false.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="internalLogIncludeTimestamp" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Write timestamps for internal NLog messages. Default value is: true.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="useInvariantCulture" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Use InvariantCulture as default culture instead of CurrentCulture.  Default value is: false.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
@@ -174,7 +194,7 @@
   <xs:complexType name="NLogInclude">
     <xs:attribute name="file" type="SimpleLayoutAttribute" use="required">
       <xs:annotation>
-        <xs:documentation>Name of the file to be included. The name is relative to the name of the current config file.</xs:documentation>
+        <xs:documentation>Name of the file to be included. You could use * wildcard. The name is relative to the name of the current config file.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="ignoreErrors" type="xs:boolean" use="optional" default="false">
@@ -1327,6 +1347,13 @@
       <xs:enumeration value="Day" />
       <xs:enumeration value="Hour" />
       <xs:enumeration value="Minute" />
+      <xs:enumeration value="Sunday" />
+      <xs:enumeration value="Monday" />
+      <xs:enumeration value="Tuesday" />
+      <xs:enumeration value="Wednesday" />
+      <xs:enumeration value="Thursday" />
+      <xs:enumeration value="Friday" />
+      <xs:enumeration value="Saturday" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="NLog.Targets.FilePathKind">
@@ -1560,6 +1587,7 @@
     <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
       <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
+      <xs:element name="parameterType" minOccurs="0" maxOccurs="1" type="xs:string" />
       <xs:element name="type" minOccurs="0" maxOccurs="1" type="xs:string" />
     </xs:choice>
     <xs:attribute name="layout" type="SimpleLayoutAttribute">
@@ -1572,9 +1600,14 @@
         <xs:documentation>Name of the parameter.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="type" type="xs:string">
+    <xs:attribute name="parameterType" type="xs:string">
       <xs:annotation>
         <xs:documentation>Type of the parameter.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="type" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Type of the parameter. Obsolete alias for </xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/src/Pickles/Pickles.CommandLine/Pickles.CommandLine.csproj
+++ b/src/Pickles/Pickles.CommandLine/Pickles.CommandLine.csproj
@@ -42,21 +42,21 @@
     <StartupObject>PicklesDoc.Pickles.CommandLine.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NDesk.Options">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.4.5\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.CommandLine/packages.config
+++ b/src/Pickles/Pickles.CommandLine/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="NDesk.Options" version="0.2.1" />
-  <package id="NLog" version="4.4.2" targetFramework="net45" />
-  <package id="NLog.Config" version="4.4.2" targetFramework="net45" />
-  <package id="NLog.Schema" version="4.4.2" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="NLog" version="4.4.5" targetFramework="net45" />
+  <package id="NLog.Config" version="4.4.5" targetFramework="net45" />
+  <package id="NLog.Schema" version="4.4.5" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Cucumber.UnitTests/Pickles.DocumentationBuilders.Cucumber.UnitTests.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Cucumber.UnitTests/Pickles.DocumentationBuilders.Cucumber.UnitTests.csproj
@@ -36,25 +36,25 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NFluent, Version=1.3.1.0, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
       <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.140\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
+    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.143\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="TechTalk.SpecFlow, Version=2.1.0.0, Culture=neutral, PublicKeyToken=0778194805d6db41, processorArchitecture=MSIL">

--- a/src/Pickles/Pickles.DocumentationBuilders.Cucumber.UnitTests/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Cucumber.UnitTests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="NFluent" version="1.3.1.0" targetFramework="net452" />
-  <package id="NUnit" version="3.6.0" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net452" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
-  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.140" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Cucumber/Pickles.DocumentationBuilders.Cucumber.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Cucumber/Pickles.DocumentationBuilders.Cucumber.csproj
@@ -31,18 +31,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.4.5\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Cucumber/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Cucumber/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NLog" version="4.4.2" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="NLog" version="4.4.5" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Dhtml.UnitTests/Pickles.DocumentationBuilders.Dhtml.UnitTests.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Dhtml.UnitTests/Pickles.DocumentationBuilders.Dhtml.UnitTests.csproj
@@ -34,18 +34,18 @@
       <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.140\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
+    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.143\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Dhtml.UnitTests/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Dhtml.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
-  <package id="NUnit" version="3.6.0" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
-  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.140" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Dhtml/Pickles.DocumentationBuilders.Dhtml.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Dhtml/Pickles.DocumentationBuilders.Dhtml.csproj
@@ -30,18 +30,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.4.5\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Dhtml/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Dhtml/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
-  <package id="NLog" version="4.4.2" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="NLog" version="4.4.5" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Excel.UnitTests/Pickles.DocumentationBuilders.Excel.UnitTests.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Excel.UnitTests/Pickles.DocumentationBuilders.Excel.UnitTests.csproj
@@ -30,12 +30,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ClosedXML, Version=0.85.0.0, Culture=neutral, PublicKeyToken=fd1eb21b62ae805b, processorArchitecture=MSIL">
-      <HintPath>..\packages\ClosedXML.0.85.0\lib\net40\ClosedXML.dll</HintPath>
+    <Reference Include="ClosedXML, Version=0.87.0.0, Culture=neutral, PublicKeyToken=fd1eb21b62ae805b, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClosedXML.0.87.1\lib\net40\ClosedXML.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DocumentFormat.OpenXml, Version=2.5.5631.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -46,8 +46,8 @@
       <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Excel.UnitTests/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Excel.UnitTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
-  <package id="ClosedXML" version="0.85.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="ClosedXML" version="0.87.1" targetFramework="net45" />
   <package id="DocumentFormat.OpenXml" version="2.5" targetFramework="net45" />
   <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
-  <package id="NUnit" version="3.6.0" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Excel/Pickles.DocumentationBuilders.Excel.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Excel/Pickles.DocumentationBuilders.Excel.csproj
@@ -30,12 +30,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ClosedXML, Version=0.85.0.0, Culture=neutral, PublicKeyToken=fd1eb21b62ae805b, processorArchitecture=MSIL">
-      <HintPath>..\packages\ClosedXML.0.85.0\lib\net40\ClosedXML.dll</HintPath>
+    <Reference Include="ClosedXML, Version=0.87.0.0, Culture=neutral, PublicKeyToken=fd1eb21b62ae805b, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClosedXML.0.87.1\lib\net40\ClosedXML.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DocumentFormat.OpenXml, Version=2.5.5631.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -43,13 +43,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.4.5\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Excel/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Excel/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
-  <package id="ClosedXML" version="0.85.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="ClosedXML" version="0.87.1" targetFramework="net45" />
   <package id="DocumentFormat.OpenXml" version="2.5" targetFramework="net45" />
-  <package id="NLog" version="4.4.2" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="NLog" version="4.4.5" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Html.UnitTests/Pickles.DocumentationBuilders.Html.UnitTests.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Html.UnitTests/Pickles.DocumentationBuilders.Html.UnitTests.csproj
@@ -30,26 +30,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NFluent, Version=1.3.1.0, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
       <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.140\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
+    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.143\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Html.UnitTests/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Html.UnitTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
-  <package id="NUnit" version="3.6.0" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
-  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.140" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Html/Pickles.DocumentationBuilders.Html.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Html/Pickles.DocumentationBuilders.Html.csproj
@@ -30,19 +30,19 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.4.5\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Html/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Html/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
-  <package id="NLog" version="4.4.2" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="NLog" version="4.4.5" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Json.UnitTests/Pickles.DocumentationBuilders.Json.UnitTests.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Json.UnitTests/Pickles.DocumentationBuilders.Json.UnitTests.csproj
@@ -30,26 +30,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NFluent, Version=1.3.1.0, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
       <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.140\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
+    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.143\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Json.UnitTests/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Json.UnitTests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
-  <package id="NUnit" version="3.6.0" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
-  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.140" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Json/Pickles.DocumentationBuilders.Json.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Json/Pickles.DocumentationBuilders.Json.csproj
@@ -30,22 +30,22 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.4.5\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Json/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Json/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NLog" version="4.4.2" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="NLog" version="4.4.5" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Word.UnitTests/Pickles.DocumentationBuilders.Word.UnitTests.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Word.UnitTests/Pickles.DocumentationBuilders.Word.UnitTests.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DocumentFormat.OpenXml, Version=2.5.5631.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -42,18 +42,18 @@
       <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.140\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
+    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.143\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Word.UnitTests/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Word.UnitTests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="DocumentFormat.OpenXml" version="2.5" targetFramework="net45" />
   <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
-  <package id="NUnit" version="3.6.0" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
-  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.140" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.DocumentationBuilders.Word/Pickles.DocumentationBuilders.Word.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Word/Pickles.DocumentationBuilders.Word.csproj
@@ -31,21 +31,21 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DocumentFormat.OpenXml">
       <HintPath>..\packages\DocumentFormat.OpenXml.2.5\lib\DocumentFormat.OpenXml.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.4.5\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Word/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Word/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
-  <package id="NLog" version="4.4.2" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="NLog" version="4.4.5" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.MSBuild/Pickles.MSBuild.csproj
+++ b/src/Pickles/Pickles.MSBuild/Pickles.MSBuild.csproj
@@ -37,8 +37,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
@@ -46,8 +46,8 @@
     <Reference Include="Microsoft.Build.Utilities.v3.5" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.MSBuild/packages.config
+++ b/src/Pickles/Pickles.MSBuild/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.ObjectModel/Pickles.ObjectModel.csproj
+++ b/src/Pickles/Pickles.ObjectModel/Pickles.ObjectModel.csproj
@@ -32,8 +32,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.ObjectModel/packages.config
+++ b/src/Pickles/Pickles.ObjectModel/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.PowerShell/Pickles.PowerShell.csproj
+++ b/src/Pickles/Pickles.PowerShell/Pickles.PowerShell.csproj
@@ -37,14 +37,14 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Management" />

--- a/src/Pickles/Pickles.PowerShell/packages.config
+++ b/src/Pickles/Pickles.PowerShell/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.Test/Formatters/HtmlContentFormatterTests.cs
+++ b/src/Pickles/Pickles.Test/Formatters/HtmlContentFormatterTests.cs
@@ -19,8 +19,8 @@
 //  --------------------------------------------------------------------------------------------------------------------
 
 using System;
-using Moq;
 using NFluent;
+using NSubstitute;
 using NUnit.Framework;
 using PicklesDoc.Pickles.DirectoryCrawler;
 using PicklesDoc.Pickles.DocumentationBuilders.Html;
@@ -42,7 +42,7 @@ namespace PicklesDoc.Pickles.Test.Formatters
         [Test]
         public void Constructor_NullHtmlIndexFormatter_ThrowsArgumentNullException()
         {
-            Check.ThatCode(() => new HtmlContentFormatter(new Mock<IHtmlFeatureFormatter>().Object, null))
+            Check.ThatCode(() => new HtmlContentFormatter(Substitute.For<IHtmlFeatureFormatter>(), null))
                 .Throws<ArgumentNullException>()
                 .WithProperty("ParamName", "htmlIndexFormatter");
         }
@@ -50,8 +50,8 @@ namespace PicklesDoc.Pickles.Test.Formatters
         [Test]
         public void Format_ContentIsFeatureNode_UsesHtmlFeatureFormatterWithCorrectArgument()
         {
-            var fakeHtmlFeatureFormatter = new Mock<IHtmlFeatureFormatter>();
-            var formatter = new HtmlContentFormatter(fakeHtmlFeatureFormatter.Object, new HtmlIndexFormatter());
+            var fakeHtmlFeatureFormatter = Substitute.For<IHtmlFeatureFormatter>();
+            var formatter = new HtmlContentFormatter(fakeHtmlFeatureFormatter, new HtmlIndexFormatter());
 
             var featureNode = new FeatureNode(
                 FileSystem.FileInfo.FromFileName(@"c:\temp\test.feature"),
@@ -60,7 +60,7 @@ namespace PicklesDoc.Pickles.Test.Formatters
 
             formatter.Format(featureNode, new INode[0]);
 
-            fakeHtmlFeatureFormatter.Verify(f => f.Format(featureNode.Feature));
+            fakeHtmlFeatureFormatter.Received().Format(featureNode.Feature);
         }
     }
 }

--- a/src/Pickles/Pickles.Test/Formatters/HtmlScenarioOutlineFormatterTests.cs
+++ b/src/Pickles/Pickles.Test/Formatters/HtmlScenarioOutlineFormatterTests.cs
@@ -23,13 +23,12 @@ using System.Collections.Generic;
 using System.Xml.Linq;
 
 using Autofac;
-using Moq;
 using NFluent;
+using NSubstitute;
 using NUnit.Framework;
 
 using PicklesDoc.Pickles.DocumentationBuilders.Html;
 using PicklesDoc.Pickles.ObjectModel;
-using PicklesDoc.Pickles.TestFrameworks;
 
 namespace PicklesDoc.Pickles.Test.Formatters
 {
@@ -41,14 +40,14 @@ namespace PicklesDoc.Pickles.Test.Formatters
         [SetUp]
         public void Setup()
         {
-            var fakeTestResults = new Mock<ITestResults>();
+            var fakeTestResults = Substitute.For<ITestResults>();
 
             this.formatter = new HtmlScenarioOutlineFormatter(
                 Container.Resolve<HtmlStepFormatter>(),
                 Container.Resolve<HtmlDescriptionFormatter>(),
                 Container.Resolve<HtmlTableFormatter>(),
                 Container.Resolve<HtmlImageResultFormatter>(),
-                fakeTestResults.Object,
+                fakeTestResults,
                 Container.Resolve<ILanguageServicesRegistry>());
         }
 

--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -35,16 +35,16 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ClosedXML, Version=0.85.0.0, Culture=neutral, PublicKeyToken=fd1eb21b62ae805b, processorArchitecture=MSIL">
-      <HintPath>..\packages\ClosedXML.0.85.0\lib\net40\ClosedXML.dll</HintPath>
+    <Reference Include="ClosedXML, Version=0.87.0.0, Culture=neutral, PublicKeyToken=fd1eb21b62ae805b, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClosedXML.0.87.1\lib\net40\ClosedXML.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DocumentFormat.OpenXml, Version=2.5.5631.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -55,8 +55,8 @@
       <HintPath>..\packages\Gherkin.4.0.0\lib\net45\Gherkin.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NFluent, Version=1.3.1.0, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
@@ -67,19 +67,19 @@
       <HintPath>..\packages\NSubstitute.2.0.2\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.140\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
+    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.143\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -55,16 +55,16 @@
       <HintPath>..\packages\Gherkin.4.0.0\lib\net45\Gherkin.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.5.30.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.5.30\lib\net45\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NFluent, Version=1.3.1.0, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
       <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NSubstitute, Version=2.0.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.2.0.2\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/Pickles/Pickles.Test/packages.config
+++ b/src/Pickles/Pickles.Test/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
-  <package id="ClosedXML" version="0.85.0" targetFramework="net45" />
+  <package id="ClosedXML" version="0.87.1" targetFramework="net45" />
   <package id="DocumentFormat.OpenXml" version="2.5" targetFramework="net45" />
   <package id="Gherkin" version="4.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
   <package id="NSubstitute" version="2.0.2" targetFramework="net45" />
-  <package id="NUnit" version="3.6.0" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
-  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.140" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.Test/packages.config
+++ b/src/Pickles/Pickles.Test/packages.config
@@ -5,9 +5,9 @@
   <package id="ClosedXML" version="0.85.0" targetFramework="net45" />
   <package id="DocumentFormat.OpenXml" version="2.5" targetFramework="net45" />
   <package id="Gherkin" version="4.0.0" targetFramework="net45" />
-  <package id="Moq" version="4.5.30" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
+  <package id="NSubstitute" version="2.0.2" targetFramework="net45" />
   <package id="NUnit" version="3.6.0" targetFramework="net45" />
   <package id="SpecFlow" version="2.1.0" targetFramework="net45" />
   <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/Pickles.TestFrameworks.UnitTests.csproj
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/Pickles.TestFrameworks.UnitTests.csproj
@@ -30,8 +30,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
@@ -46,19 +46,19 @@
       <HintPath>..\packages\NSubstitute.2.0.2\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.140\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
+    <Reference Include="System.IO.Abstractions.TestingHelpers, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.143\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/Pickles.TestFrameworks.UnitTests.csproj
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/Pickles.TestFrameworks.UnitTests.csproj
@@ -38,12 +38,12 @@
       <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.5.30.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.5.30\lib\net45\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="NFluent, Version=1.3.1.0, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
       <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NSubstitute, Version=2.0.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.2.0.2\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/SpecRun/WhenParsingMultipleTestResultsTests.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/SpecRun/WhenParsingMultipleTestResultsTests.cs
@@ -22,9 +22,9 @@ using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 
-using Moq;
-
 using NFluent;
+
+using NSubstitute;
 
 using NUnit.Framework;
 
@@ -43,7 +43,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
             var testResults1 = SetupStubForGetFeatureResult(feature, TestResult.Passed);
             var testResults2 = SetupStubForGetFeatureResult(feature, TestResult.Inconclusive);
 
-            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1.Object, testResults2.Object);
+            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1, testResults2);
 
             var result = multipleTestResults.GetFeatureResult(feature);
 
@@ -63,10 +63,10 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
             }
         }
 
-        private static Mock<SingleTestRunBase> SetupStubForGetFeatureResult(Feature feature, TestResult resultOfGetFeatureResult)
+        private static SingleTestRunBase SetupStubForGetFeatureResult(Feature feature, TestResult resultOfGetFeatureResult)
         {
-            var testResults1 = new Mock<SingleTestRunBase>();
-            testResults1.Setup(ti => ti.GetFeatureResult(feature)).Returns(resultOfGetFeatureResult);
+            var testResults1 = Substitute.For<SingleTestRunBase>();
+            testResults1.GetFeatureResult(feature).Returns(resultOfGetFeatureResult);
             return testResults1;
         }
 
@@ -78,7 +78,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
             var testResults1 = SetupStubForGetFeatureResult(feature, TestResult.Passed);
             var testResults2 = SetupStubForGetFeatureResult(feature, TestResult.Failed);
 
-            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1.Object, testResults2.Object);
+            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1, testResults2);
 
             var result = multipleTestResults.GetFeatureResult(feature);
 
@@ -93,7 +93,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
             var testResults1 = SetupStubForGetFeatureResult(feature, TestResult.Inconclusive);
             var testResults2 = SetupStubForGetFeatureResult(feature, TestResult.Inconclusive);
 
-            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1.Object, testResults2.Object);
+            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1, testResults2);
 
             var result = multipleTestResults.GetFeatureResult(feature);
 
@@ -108,17 +108,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
             var testResults1 = SetupStubForGetScenarioOutlineResult(TestResult.Passed);
             var testResults2 = SetupStubForGetScenarioOutlineResult(TestResult.Inconclusive);
 
-            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1.Object, testResults2.Object);
+            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1, testResults2);
 
             var result = multipleTestResults.GetScenarioOutlineResult(scenarioOutline);
 
             Check.That(result).IsEqualTo(TestResult.Passed);
         }
 
-        private static Mock<SingleTestRunBase> SetupStubForGetScenarioOutlineResult(TestResult resultOfGetFeatureResult)
+        private static SingleTestRunBase SetupStubForGetScenarioOutlineResult(TestResult resultOfGetFeatureResult)
         {
-            var testResults1 = new Mock<SingleTestRunBase>();
-            testResults1.Setup(ti => ti.GetScenarioOutlineResult(It.IsAny<ScenarioOutline>())).Returns(resultOfGetFeatureResult);
+            var testResults1 = Substitute.For<SingleTestRunBase>();
+            testResults1.GetScenarioOutlineResult(Arg.Any<ScenarioOutline>()).Returns(resultOfGetFeatureResult);
             return testResults1;
         }
 
@@ -130,7 +130,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
             var testResults1 = SetupStubForGetScenarioOutlineResult(TestResult.Passed);
             var testResults2 = SetupStubForGetScenarioOutlineResult(TestResult.Failed);
 
-            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1.Object, testResults2.Object);
+            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1, testResults2);
 
             var result = multipleTestResults.GetScenarioOutlineResult(scenarioOutline);
 
@@ -145,7 +145,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
             var testResults1 = SetupStubForGetScenarioOutlineResult(TestResult.Inconclusive);
             var testResults2 = SetupStubForGetScenarioOutlineResult(TestResult.Inconclusive);
 
-            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1.Object, testResults2.Object);
+            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1, testResults2);
 
             var result = multipleTestResults.GetScenarioOutlineResult(scenarioOutline);
 
@@ -160,17 +160,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
             var testResults1 = SetupStubForGetScenarioResult(TestResult.Passed);
             var testResults2 = SetupStubForGetScenarioResult(TestResult.Inconclusive);
 
-            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1.Object, testResults2.Object);
+            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1, testResults2);
 
             var result = multipleTestResults.GetScenarioResult(scenario);
 
             Check.That(result).IsEqualTo(TestResult.Passed);
         }
 
-        private static Mock<SingleTestRunBase> SetupStubForGetScenarioResult(TestResult resultOfGetFeatureResult)
+        private static SingleTestRunBase SetupStubForGetScenarioResult(TestResult resultOfGetFeatureResult)
         {
-            var testResults1 = new Mock<SingleTestRunBase>();
-            testResults1.Setup(ti => ti.GetScenarioResult(It.IsAny<Scenario>())).Returns(resultOfGetFeatureResult);
+            var testResults1 = Substitute.For<SingleTestRunBase>();
+            testResults1.GetScenarioResult(Arg.Any<Scenario>()).Returns(resultOfGetFeatureResult);
             return testResults1;
         }
 
@@ -182,7 +182,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
             var testResults1 = SetupStubForGetScenarioResult(TestResult.Passed);
             var testResults2 = SetupStubForGetScenarioResult(TestResult.Failed);
 
-            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1.Object, testResults2.Object);
+            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1, testResults2);
 
             var result = multipleTestResults.GetScenarioResult(scenario);
 
@@ -197,7 +197,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
             var testResults1 = SetupStubForGetScenarioResult(TestResult.Inconclusive);
             var testResults2 = SetupStubForGetScenarioResult(TestResult.Inconclusive);
 
-            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1.Object, testResults2.Object);
+            ITestResults multipleTestResults = CreateMultipleTestResults(testResults1, testResults2);
 
             var result = multipleTestResults.GetScenarioResult(scenario);
 

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/packages.config
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
   <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
   <package id="NSubstitute" version="2.0.2" targetFramework="net45" />
-  <package id="NUnit" version="3.6.0" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
-  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.140" targetFramework="net45" />
+  <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/packages.config
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Autofac" version="4.3.0" targetFramework="net45" />
   <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
-  <package id="Moq" version="4.5.30" targetFramework="net45" />
   <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
+  <package id="NSubstitute" version="2.0.2" targetFramework="net45" />
   <package id="NUnit" version="3.6.0" targetFramework="net45" />
   <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
   <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.140" targetFramework="net45" />

--- a/src/Pickles/Pickles.TestFrameworks/Pickles.TestFrameworks.csproj
+++ b/src/Pickles/Pickles.TestFrameworks/Pickles.TestFrameworks.csproj
@@ -30,15 +30,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/src/Pickles/Pickles.TestFrameworks/packages.config
+++ b/src/Pickles/Pickles.TestFrameworks/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.UserInterface/NLog.xsd
+++ b/src/Pickles/Pickles.UserInterface/NLog.xsd
@@ -42,12 +42,32 @@
     </xs:attribute>
     <xs:attribute name="throwExceptions" type="xs:boolean">
       <xs:annotation>
-        <xs:documentation>Pass NLog internal exceptions to the application. Default value is: false.</xs:documentation>
+        <xs:documentation>Throw an exception when there is an internal error. Default value is: false.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="throwConfigExceptions" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Throw an exception when there is a configuration error. If not set, determined by throwExceptions.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="keepVariablesOnReload" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Gets or sets a value indicating whether Variables should be kept on configuration reload. Default value is: false.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="internalLogToTrace" type="xs:boolean">
       <xs:annotation>
-        <xs:documentation>Write internal NLog messages to the the System.Diagnostics.Trace. Default value is: false</xs:documentation>
+        <xs:documentation>Write internal NLog messages to the System.Diagnostics.Trace. Default value is: false.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="internalLogIncludeTimestamp" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Write timestamps for internal NLog messages. Default value is: true.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="useInvariantCulture" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>Use InvariantCulture as default culture instead of CurrentCulture.  Default value is: false.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
@@ -174,7 +194,7 @@
   <xs:complexType name="NLogInclude">
     <xs:attribute name="file" type="SimpleLayoutAttribute" use="required">
       <xs:annotation>
-        <xs:documentation>Name of the file to be included. The name is relative to the name of the current config file.</xs:documentation>
+        <xs:documentation>Name of the file to be included. You could use * wildcard. The name is relative to the name of the current config file.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="ignoreErrors" type="xs:boolean" use="optional" default="false">
@@ -1327,6 +1347,13 @@
       <xs:enumeration value="Day" />
       <xs:enumeration value="Hour" />
       <xs:enumeration value="Minute" />
+      <xs:enumeration value="Sunday" />
+      <xs:enumeration value="Monday" />
+      <xs:enumeration value="Tuesday" />
+      <xs:enumeration value="Wednesday" />
+      <xs:enumeration value="Thursday" />
+      <xs:enumeration value="Friday" />
+      <xs:enumeration value="Saturday" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="NLog.Targets.FilePathKind">
@@ -1560,6 +1587,7 @@
     <xs:choice minOccurs="0" maxOccurs="unbounded">
       <xs:element name="layout" minOccurs="0" maxOccurs="1" type="Layout" />
       <xs:element name="name" minOccurs="0" maxOccurs="1" type="xs:string" />
+      <xs:element name="parameterType" minOccurs="0" maxOccurs="1" type="xs:string" />
       <xs:element name="type" minOccurs="0" maxOccurs="1" type="xs:string" />
     </xs:choice>
     <xs:attribute name="layout" type="SimpleLayoutAttribute">
@@ -1572,9 +1600,14 @@
         <xs:documentation>Name of the parameter.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="type" type="xs:string">
+    <xs:attribute name="parameterType" type="xs:string">
       <xs:annotation>
         <xs:documentation>Type of the parameter.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="type" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Type of the parameter. Obsolete alias for </xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/src/Pickles/Pickles.UserInterface/Pickles.UserInterface.csproj
+++ b/src/Pickles/Pickles.UserInterface/Pickles.UserInterface.csproj
@@ -45,8 +45,8 @@
     <ApplicationIcon>Pickles.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="GalaSoft.MvvmLight, Version=5.3.0.19026, Culture=neutral, PublicKeyToken=e7570ab207bcb616, processorArchitecture=MSIL">
@@ -69,7 +69,7 @@
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.4.5\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NlogViewer, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -82,8 +82,8 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />

--- a/src/Pickles/Pickles.UserInterface/packages.config
+++ b/src/Pickles/Pickles.UserInterface/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net4" />
   <package id="MahApps.Metro" version="1.4.3" targetFramework="net45" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net45" />
-  <package id="NLog" version="4.4.2" targetFramework="net45" />
-  <package id="NLog.Config" version="4.4.2" targetFramework="net45" />
-  <package id="NLog.Schema" version="4.4.2" targetFramework="net45" />
+  <package id="NLog" version="4.4.5" targetFramework="net45" />
+  <package id="NLog.Config" version="4.4.5" targetFramework="net45" />
+  <package id="NLog.Schema" version="4.4.5" targetFramework="net45" />
   <package id="NlogViewer" version="0.6.0.0" targetFramework="net45" />
   <package id="Ookii.Dialogs" version="1.0" requireReinstallation="true" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/src/Pickles/Pickles.sln.GhostDoc.xml
+++ b/src/Pickles/Pickles.sln.GhostDoc.xml
@@ -16,6 +16,7 @@
     <OutputPath>.\Help</OutputPath>
     <CleanupOutputPath>true</CleanupOutputPath>
     <HelpFileName>Pickles</HelpFileName>
+    <HelpFileNamingMethod>MemberName</HelpFileNamingMethod>
     <ImageFolderPath />
     <Theme />
     <HtmlFormats>

--- a/src/Pickles/Pickles/Pickles.csproj
+++ b/src/Pickles/Pickles/Pickles.csproj
@@ -35,12 +35,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.5.0\lib\net45\Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ClosedXML, Version=0.85.0.0, Culture=neutral, PublicKeyToken=fd1eb21b62ae805b, processorArchitecture=MSIL">
-      <HintPath>..\packages\ClosedXML.0.85.0\lib\net40\ClosedXML.dll</HintPath>
+    <Reference Include="ClosedXML, Version=0.87.0.0, Culture=neutral, PublicKeyToken=fd1eb21b62ae805b, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClosedXML.0.87.1\lib\net40\ClosedXML.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DocumentFormat.OpenXml, Version=2.5.5631.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -66,12 +66,12 @@
     <Reference Include="NDesk.Options">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.4.2\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.4.5\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Strike.Jint">
@@ -80,8 +80,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO.Abstractions, Version=2.0.0.140, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IO.Abstractions.2.0.0.140\lib\net40\System.IO.Abstractions.dll</HintPath>
+    <Reference Include="System.IO.Abstractions, Version=2.0.0.143, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.143\lib\net40\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/src/Pickles/Pickles/packages.config
+++ b/src/Pickles/Pickles/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.3.0" targetFramework="net45" />
-  <package id="ClosedXML" version="0.85.0" targetFramework="net45" />
+  <package id="Autofac" version="4.5.0" targetFramework="net45" />
+  <package id="ClosedXML" version="0.87.1" targetFramework="net45" />
   <package id="DocumentFormat.OpenXml" version="2.5" targetFramework="net45" />
   <package id="FeatureSwitcher" version="1.1.0" targetFramework="net45" />
   <package id="Gherkin" version="4.0.0" targetFramework="net45" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net35" />
   <package id="NDesk.Options" version="0.2.1" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NLog" version="4.4.2" targetFramework="net45" />
-  <package id="System.IO.Abstractions" version="2.0.0.140" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
+  <package id="NLog" version="4.4.5" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.0.0.143" targetFramework="net45" />
 </packages>

--- a/test-harness/AutomationLayer/AdditionSteps.cs
+++ b/test-harness/AutomationLayer/AdditionSteps.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using Shouldly;
+using NFluent;
 using TechTalk.SpecFlow;
 
 namespace AutomationLayer
@@ -22,13 +22,13 @@ namespace AutomationLayer
         [Given(@"the background step fails")]
         public void GivenTheBackgroundStepFails()
         {
-            1.ShouldBe(2);
+            MarkTestAs.Failing();
         }
 
         [Given(@"I have entered (.*) into the calculator")]
-        public void GivenIHaveEnteredIntoTheCalculator(Decimal p0)
+        public void GivenIHaveEnteredIntoTheCalculator(decimal operand)
         {
-            this.numbersList.Add((int)p0);
+            this.numbersList.Add((int)operand);
         }
 
         [When(@"I press add")]
@@ -41,9 +41,9 @@ namespace AutomationLayer
         }
 
         [Then(@"the result should be (.*) on the screen")]
-        public void ThenTheResultShouldBeOnTheScreen(int p0)
+        public void ThenTheResultShouldBeOnTheScreen(int expectedResult)
         {
-            this.result.ShouldBe(p0);
+            Check.That(this.result).IsEqualTo(expectedResult);
         }
     }
 }

--- a/test-harness/AutomationLayer/AutomationLayer.csproj
+++ b/test-harness/AutomationLayer/AutomationLayer.csproj
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Shouldly, Version=2.8.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <HintPath>..\packages\Shouldly.2.8.2\lib\net40\Shouldly.dll</HintPath>
+    <Reference Include="NFluent, Version=1.3.1.0, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
+      <HintPath>..\packages\NFluent.1.3.1.0\lib\net40\NFluent.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AdditionSteps.cs" />
+    <Compile Include="MarkTestAs.cs" />
     <Compile Include="MinimalFeatures\MinimalSteps.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScenarioOutlineSteps.cs" />

--- a/test-harness/AutomationLayer/MarkTestAs.cs
+++ b/test-harness/AutomationLayer/MarkTestAs.cs
@@ -1,0 +1,23 @@
+﻿using NFluent;
+using TechTalk.SpecFlow;
+
+namespace AutomationLayer
+{
+    public static class MarkTestAs
+    {
+        internal static void Inconclusive()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+        internal static void Failing()
+        {
+            Check.That(true).IsEqualTo(false);
+        }
+
+        internal static void Passing()
+        {
+            // nothing to be done
+        }
+    }
+}

--- a/test-harness/AutomationLayer/MinimalFeatures/MinimalSteps.cs
+++ b/test-harness/AutomationLayer/MinimalFeatures/MinimalSteps.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Shouldly;
 using TechTalk.SpecFlow;
 
 namespace AutomationLayer.MinimalFeatures
@@ -10,18 +9,19 @@ namespace AutomationLayer.MinimalFeatures
         [Then(@"passing step")]
         public void ThenPassingStep()
         {
+            MarkTestAs.Passing();
         }
-        
+
         [Then(@"inconclusive step")]
         public void ThenInconclusiveStep()
         {
-            ScenarioContext.Current.Pending();
+            MarkTestAs.Inconclusive();
         }
-        
+
         [Then(@"failing step")]
         public void ThenFailingStep()
         {
-            true.ShouldBe(false);
+            MarkTestAs.Failing();
         }
     }
 }

--- a/test-harness/AutomationLayer/ScenarioOutlineSteps.cs
+++ b/test-harness/AutomationLayer/ScenarioOutlineSteps.cs
@@ -1,53 +1,51 @@
 ﻿using System;
 
-using Shouldly;
-
 using TechTalk.SpecFlow;
 
 namespace AutomationLayer
 {
-  [Binding]
-  public class ScenarioOutlineSteps
-  {
-    [Then(@"the scenario will '(.*)'")]
-    public void ThenTheScenarioWill(string result)
+    [Binding]
+    public class ScenarioOutlineSteps
     {
-        if (result.ToUpperInvariant().StartsWith("PASS"))
+        [Then(@"the scenario will '(.*)'")]
+        public void ThenTheScenarioWill(string result)
         {
-        // nothing to be done
+            if (result.ToUpperInvariant().StartsWith("PASS"))
+            {
+                MarkTestAs.Passing();
+            }
+            else if (result.ToUpperInvariant().StartsWith("FAIL"))
+            {
+                MarkTestAs.Failing();
+            }
+            else
+            {
+                MarkTestAs.Inconclusive();
+            }
         }
-        else if (result.ToUpperInvariant().StartsWith("FAIL"))
+
+        [When(@"I have special characters for regexes in the value, for example a '(.*)'")]
+        public void WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex(string regex)
         {
-        true.ShouldBe(false);
+            // nothing to be done
         }
-        else
+
+        [When(@"I have backslashes in the value, for example a '(.*)'")]
+        public void WhenIHaveBackslashesInTheValueForExampleAFilePath(string filePath)
         {
-        ScenarioContext.Current.Pending();
+            // nothing to be done
+        }
+
+        [When(@"I have parenthesis in the value, for example an '(.*)'")]
+        public void WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField(string description)
+        {
+            // nothing to be done - test case requires pass
+        }
+
+        [When(@"I have a field with value '(.*)'")]
+        public void WhenIHaveAFieldWithValue(string value)
+        {
+            // nothing to be done - test case requires pass
         }
     }
-
-    [When(@"I have special characters for regexes in the value, for example a '(.*)'")]
-    public void WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex(string regex)
-    {
-        // nothing to be done
-    }    
-
-    [When(@"I have backslashes in the value, for example a '(.*)'")]
-    public void WhenIHaveBackslashesInTheValueForExampleAFilePath(string filePath)
-    {
-        // nothing to be done
-    }
-
-    [When(@"I have parenthesis in the value, for example an '(.*)'")]
-    public void WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField(string description)
-    {
-        // nothing to be done - test case requires pass
-    }
-    
-    [When(@"I have a field with value '(.*)'")]
-    public void WhenIHaveAFieldWithValue(string value)
-    {
-        // nothing to be done - test case requires pass
-    }
-  }
 }

--- a/test-harness/AutomationLayer/packages.config
+++ b/test-harness/AutomationLayer/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Shouldly" version="2.8.2" targetFramework="net45" />
+  <package id="NFluent" version="1.3.1.0" targetFramework="net45" />
   <package id="SpecFlow" version="1.9.0" targetFramework="net45" />
 </packages>

--- a/test-harness/SpecRun/App.config
+++ b/test-harness/SpecRun/App.config
@@ -13,4 +13,12 @@
           <add name="SpecRun" />
       </plugins>
   </specFlow>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="TechTalk.SpecFlow" publicKeyToken="0778194805d6db41" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.9.0.77" newVersion="1.9.0.77" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/test-harness/TestHarness.sln.GhostDoc.xml
+++ b/test-harness/TestHarness.sln.GhostDoc.xml
@@ -16,6 +16,7 @@
     <OutputPath>.\Help</OutputPath>
     <CleanupOutputPath>true</CleanupOutputPath>
     <HelpFileName>TestHarness</HelpFileName>
+    <HelpFileNamingMethod>MemberName</HelpFileNamingMethod>
     <ImageFolderPath />
     <Theme />
     <HtmlFormats>


### PR DESCRIPTION
Fileencoding used is always default. If files are encoding with another encoding, it fails when parsing the files.
with this pull request, encoding is deduced from reading first 4 bytes. Fallback is default encoding.